### PR TITLE
Try to refactor the roles needed member

### DIFF
--- a/src/main/java/com/techdegree/instateam/model/Role.java
+++ b/src/main/java/com/techdegree/instateam/model/Role.java
@@ -63,14 +63,6 @@ public class Role {
 
     }
     @Override
-    public String toString() {
-        return "Role{" +
-                "id=" + id +
-                ", name='" + name + '\'' +
-                '}';
-    }
-
-    @Override
     public int hashCode() {
         int result = id;
         result = 31 * result + (name != null ? name.hashCode() : 0);

--- a/src/main/resources/static/css/site.css
+++ b/src/main/resources/static/css/site.css
@@ -260,9 +260,10 @@ strong {
 	border-bottom-width: 0px;
 }
 .error.role.project span{
-	color: brown;
+	color: grey;
 }
 .error.role.project span.validation{
+	color: brown;
     position: relative;
 	bottom: 10px;
 }

--- a/src/main/resources/templates/project/project-edit.html
+++ b/src/main/resources/templates/project/project-edit.html
@@ -25,9 +25,9 @@
                             Validation Error Message
                         </span>
                         <!--/* project name input, attr 'required' is for server
-                               side validation
+                               side validation.
                          */-->
-                        <label for="project_name"> Project Name:</label>
+                        <label th:for="${#fields.idFromName('name')}"> Project Name:</label>
                         <input th:field="*{name}"
                                type="text"
                                required
@@ -48,7 +48,7 @@
                         <!--/* project description input, attr 'required'
                                is for server side validation
                          */-->
-                        <label for="project_description">
+                        <label th:for="${#fields.idFromName('description')}">
                             Project Description:
                         </label>
                         <textarea th:field="*{description}"
@@ -62,7 +62,9 @@
                            easily changed later
                     */-->
                     <div>
-                        <label for="project_status">Project Status:</label>
+                        <label th:for="${#fields.idFromName('status')}">
+                            Project Status:
+                        </label>
                         <div class="custom-select">
                          <!--/* arrow on selector */-->
                         <span class="dropdown-arrow"></span>
@@ -94,7 +96,17 @@
                               class="validation">
                             Please select at least one Role
                         </span>
-                        <label for="project_roles">Project Roles:</label>
+                        <!--/* This label does not point to anywhere, so I
+                               because we have many roles with many ids.
+                               It is better be changed to simple span. May be
+                               It is wrong, but it feels better
+                        */-->
+                        <!--/*
+                            <label for="project_roles">Project Roles:</label>
+                        */-->
+                        <span th:if="${#fields.hasErrors('rolesNeeded') == false}">
+                            Project Roles:
+                        </span>
                         <!--/* list with all roles */-->
                         <ul class="checkbox-list">
                             <li th:each="role : ${allRoles}">

--- a/src/main/resources/templates/project/project-edit.html
+++ b/src/main/resources/templates/project/project-edit.html
@@ -15,35 +15,51 @@
                 <form th:action="@{|/projects/${action}|}"
                       th:object="${project}"
                       method="post">
+                    <!--/* In case of error class of this div will change to
+                        error class
+                    */-->
                     <div th:classappend="${#fields.hasErrors('name')}? 'error name project' : ''">
                         <!--/* Validation error message */-->
                         <span th:if="${#fields.hasErrors('name')}"
                               th:errors="*{name}">
                             Validation Error Message
                         </span>
-                        <!--/* project name input, required: server side
-                               validation */-->
+                        <!--/* project name input, attr 'required' is for server
+                               side validation
+                         */-->
                         <label for="project_name"> Project Name:</label>
                         <input th:field="*{name}"
                                type="text"
                                required
                                name="project_name">
                     </div>
-                    <!--/* No validation messages for project description, because
-                           its only validation is being not null, and browser
-                           takes care of this with "required" attribute. So
-                           nothing for now
+                    <!--/* No validation messages for project description,
+                           because its only validation is being not null, and
+                           browser takes care of this with "required" attribute.
+                           But just in case we add something I'll leave this
+                           error class here
                      */-->
-                    <div>
-                        <label for="project_description">Project Description:</label>
+                    <div th:classappend="${#fields.hasErrors('name')}? 'error name project' : ''">
+                        <!--/* Validation error message */-->
+                        <span th:if="${#fields.hasErrors('name')}"
+                              th:errors="*{name}">
+                        Validation Error Message
+                    </span>
+                        <!--/* project description input, attr 'required'
+                               is for server side validation
+                         */-->
+                        <label for="project_description">
+                            Project Description:
+                        </label>
                         <textarea th:field="*{description}"
                                 rows="4"
                                 name="project_description"
                                 required>
                         </textarea>
                     </div>
-                    <!--/* No validation for project, because I want to make
-                           "Not started" by default here
+                    <!--/* No validation div for 'status', because I want to
+                           make "Not started" by default here. Can be
+                           easily changed later
                     */-->
                     <div>
                         <label for="project_status">Project Status:</label>
@@ -67,38 +83,42 @@
                             </select>
                         </div>
                     </div>
-                    <!--/* This is validated manually, when field is invalid,
-                           rolesError is passed to model,
-                           see controller. Unfortunately roles checked by user
-                           not saved. Could be implemented with Validation
-                           Service?
+                    <!--/* This is validated manually, see controller method,
+                           but '#fields.hasErrors' can be used because we set
+                           it accordingly
                     */-->
-                    <div th:classappend="${rolesError != null}? 'error role project' : ''">
+                    <div th:classappend="${#fields.hasErrors('rolesNeeded')}? 'error role project' : ''">
                         <!--/* Custom validation error message */-->
-                        <span th:if="${rolesError != null}"
-                              th:text="${rolesError}"
+                        <span th:if="${#fields.hasErrors('rolesNeeded')}"
+                              th:errors="*{rolesNeeded}"
                               class="validation">
-                        Please select at least one Role
+                            Please select at least one Role
                         </span>
                         <label for="project_roles">Project Roles:</label>
+                        <!--/* list with all roles */-->
                         <ul class="checkbox-list">
-                            <!--/* Tricky part: here I print all roles,
-                                   but for input.value I use role.id member.
-                                   Why? Otherwise I have to write custom
-                                   validator and|or converted of Role. It gives
-                                   me validation error message. So I collect
-                                   empty roles, with names equal to null, and
-                                   if selected id will non-zero, this way I know
-                                   what user has selected. The other question is
-                                   why not to attach Role name somehow, well
-                                   I tried, it didn't work. This is the only
-                                   way
-                            */-->
                             <li th:each="role : ${allRoles}">
-                                <input th:value="${role.id}"
-                                       th:field="*{rolesNeeded[__${roleStat.index}__].id}"
-                                       type="checkbox"
-                                       >
+                                <!--/*
+                                     here we set selected role id of
+                                     rolesNeeded. Without this id will be 0
+                                */-->
+                                <select hidden th:field="*{rolesNeeded[__${roleStat.index}__].id}">
+                                    <option th:value="${role.id}"></option>
+                                </select>
+                                <!--/*
+                                     here we set selected role name of
+                                     rolesNeeded. Without this name will be null
+                                */-->
+                                <select hidden th:field="*{rolesNeeded[__${roleStat.index}__].name}">
+                                    <option th:value="${role.name}"></option>
+                                </select>
+                                <!--/* Main checkbox where we attach checked
+                                       Role to one of the RolesNeeded elements.
+                                       Unchecked roles will be null
+                                */-->
+                                <input th:value="${role}"
+                                       th:field="*{rolesNeeded[__${roleStat.index}__]}"
+                                       type="checkbox">
                                 <!--/* Prints role name near checkbox */-->
                                 <span th:text="${role.name}"
                                       class="primary">


### PR DESCRIPTION
Now roles are much better and understandably incorporated. When selected by user, are filtered by non-null values, and ids and role names are correctly done. Now correct validation error is set to field 'rolesNeeded' and wrong user input, i.e. selected roles is saved. And there is only one redirect. Labels are corrected in thymeleaf. Now they don't have ghost `for` attributes
