### PR TITLE
Data integrity upon delete part 2 delete project

### DIFF
--- a/src/main/java/com/techdegree/instateam/dao/ProjectDao.java
+++ b/src/main/java/com/techdegree/instateam/dao/ProjectDao.java
@@ -8,4 +8,5 @@ public interface ProjectDao {
     List<Project> findAll();
     void save(Project project);
     Project findById(int projectId);
+    void remove(Project project);
 }

--- a/src/main/java/com/techdegree/instateam/dao/ProjectDaoImpl.java
+++ b/src/main/java/com/techdegree/instateam/dao/ProjectDaoImpl.java
@@ -50,4 +50,16 @@ public class ProjectDaoImpl implements ProjectDao {
         session.close();
         return project;
     }
+
+    @Override
+    public void remove(Project project) {
+        Session session = sessionFactory.openSession();
+        // detach project from project_roles link table,
+        // detach project from project_collaborators link table
+        // delete project from his table: begin transaction, delete, commit
+        session.beginTransaction();
+        session.delete(project);
+        session.getTransaction().commit();
+        session.close();
+    }
 }

--- a/src/main/java/com/techdegree/instateam/dao/ProjectDaoImpl.java
+++ b/src/main/java/com/techdegree/instateam/dao/ProjectDaoImpl.java
@@ -55,7 +55,15 @@ public class ProjectDaoImpl implements ProjectDao {
     public void remove(Project project) {
         Session session = sessionFactory.openSession();
         // detach project from project_roles link table,
+        session.createSQLQuery(
+                "DELETE PUBLIC.projects_roles " +
+                        "WHERE PROJECTS_ID = " + project.getId())
+                .executeUpdate();
         // detach project from project_collaborators link table
+        session.createSQLQuery(
+                "DELETE PUBLIC.projects_collaborators " +
+                        "WHERE PROJECT_ID = " + project.getId())
+                .executeUpdate();
         // delete project from his table: begin transaction, delete, commit
         session.beginTransaction();
         session.delete(project);

--- a/src/main/java/com/techdegree/instateam/service/ProjectService.java
+++ b/src/main/java/com/techdegree/instateam/service/ProjectService.java
@@ -8,4 +8,5 @@ public interface ProjectService {
     List<Project> findAll();
     void save(Project project);
     Project findById(int projectId);
+    void delete(Project project);
 }

--- a/src/main/java/com/techdegree/instateam/service/ProjectServiceImpl.java
+++ b/src/main/java/com/techdegree/instateam/service/ProjectServiceImpl.java
@@ -26,4 +26,9 @@ public class ProjectServiceImpl implements ProjectService {
     public Project findById(int projectId) {
         return projectDao.findById(projectId);
     }
+
+    @Override
+    public void delete(Project project) {
+        projectDao.remove(project);
+    }
 }

--- a/src/main/java/com/techdegree/instateam/web/controller/ProjectController.java
+++ b/src/main/java/com/techdegree/instateam/web/controller/ProjectController.java
@@ -428,6 +428,32 @@ public class ProjectController {
                + actualProjectToBeFilledWithCollaborators.getId() +
                "/details";
     }
+    // delete project request
+    @RequestMapping(value = "/projects/{projectId}/delete")
+    public String deleteProject(
+            @PathVariable int projectId,
+            RedirectAttributes redirectAttributes
+    ) {
+        // find project by id
+        Project project = projectService.findById(projectId);
+
+        // if project is not found throw not found error page
+        if (project == null) {
+            throw new NotFoundException("Project not found");
+        }
+
+        // delete Project from database
+        projectService.delete(project);
+
+        // set flash message on top in redirected page
+        redirectAttributes.addFlashAttribute("flash", new FlashMessage(
+                "Project '" + project.getName() +
+                        "' was successfully deleted!",
+                FlashMessage.Status.SUCCESS
+        ));
+        // redirect back to home page
+        return "redirect:/";
+    }
     // If anywhere NotFoundException is thrown we return error page,
     // i set custom status here, because for some reason otherwise
     // status is 200 :(

--- a/src/main/resources/static/css/site.css
+++ b/src/main/resources/static/css/site.css
@@ -125,6 +125,10 @@ nav ul li.selected a {
     bottom: 13px;
     left: 5px;
 }
+.button.delete.project {
+	bottom: 0px;
+    padding-top: 15px;
+}
 .button.button-secondary {
 	background: transparent;
 	border-color: #e1e0e0;

--- a/src/main/resources/templates/project/project-details.html
+++ b/src/main/resources/templates/project/project-details.html
@@ -111,6 +111,11 @@
                            th:href="@{|/projects/${project.id}/collaborators|}">
                             Edit Collaborators
                         </a>
+                        <!--/* Button deleting project */-->
+                        <a class="button delete project"
+                           th:href="@{|/projects/${project.id}/delete|}">
+                            Delete Project
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Now data integrity is ensured upon `Project` deletion:
From both `project_roles` link table and `projects_collaborators` links to deleted projects are deleted.
Added delete button to project details page, with new CSS style for it. 
With this said, data integrity is over. May be using SQL commands, but it is ensured.
