### PR TITLE
Create abstract dao interface and make other daos extend it

### DIFF
--- a/src/main/java/com/techdegree/instateam/dao/CollaboratorDao.java
+++ b/src/main/java/com/techdegree/instateam/dao/CollaboratorDao.java
@@ -2,11 +2,5 @@ package com.techdegree.instateam.dao;
 
 import com.techdegree.instateam.model.Collaborator;
 
-import java.util.List;
-
-public interface CollaboratorDao {
-    List<Collaborator> findAll();
-    Collaborator findById(int id);
-    void save(Collaborator collaborator);
-    void delete(Collaborator collaborator);
+public interface CollaboratorDao extends GenericDao<Collaborator> {
 }

--- a/src/main/java/com/techdegree/instateam/dao/CollaboratorDaoImpl.java
+++ b/src/main/java/com/techdegree/instateam/dao/CollaboratorDaoImpl.java
@@ -9,36 +9,9 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public class CollaboratorDaoImpl implements CollaboratorDao {
-    @Autowired
-    private SessionFactory sessionFactory;
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public List<Collaborator> findAll() {
-        Session session = sessionFactory.openSession();
-        List<Collaborator> collaborators =
-                session.createCriteria(Collaborator.class).list();
-        session.close();
-        return collaborators;
-    }
-
-    @Override
-    public Collaborator findById(int id) {
-        Session session = sessionFactory.openSession();
-        Collaborator collaborator = session.get(Collaborator.class, id);
-        session.close();
-        return collaborator;
-    }
-
-    @Override
-    public void save(Collaborator collaborator) {
-        Session session = sessionFactory.openSession();
-        session.beginTransaction();
-        session.saveOrUpdate(collaborator);
-        session.getTransaction().commit();
-        session.close();
-    }
+public class CollaboratorDaoImpl
+        extends GenericDaoImpl<Collaborator>
+        implements CollaboratorDao {
 
     @Override
     public void delete(Collaborator collaborator) {

--- a/src/main/java/com/techdegree/instateam/dao/GenericDao.java
+++ b/src/main/java/com/techdegree/instateam/dao/GenericDao.java
@@ -1,0 +1,10 @@
+package com.techdegree.instateam.dao;
+
+import java.util.List;
+
+public interface GenericDao<T> {
+    List<T> findAll();
+    void save(T object);
+    T findById(int objectId);
+    void delete(T object);
+}

--- a/src/main/java/com/techdegree/instateam/dao/GenericDaoImpl.java
+++ b/src/main/java/com/techdegree/instateam/dao/GenericDaoImpl.java
@@ -13,7 +13,13 @@ import java.util.List;
 // It is changed a bit: namely I haven't used Serializable id, but this may be
 // done later when I make this app testable, so that I'm not afraid to make
 // changes and check manually whether this page or this works
-public class GenericDaoImpl<T> implements GenericDao<T>{
+/** Comments from codesenior.com
+ * By defining this class as abstract, we prevent Spring from creating
+ * instance of this class If not defined as abstract,
+ * getClass().getGenericSuperClass() would return Object. There would be
+ * exception because Object class does not hava constructor with parameters.
+ */
+public abstract class GenericDaoImpl<T> implements GenericDao<T>{
     // session factory: will be used in all concrete Dao implementations
     @Autowired
     protected SessionFactory sessionFactory;

--- a/src/main/java/com/techdegree/instateam/dao/GenericDaoImpl.java
+++ b/src/main/java/com/techdegree/instateam/dao/GenericDaoImpl.java
@@ -1,0 +1,88 @@
+package com.techdegree.instateam.dao;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+// This method was taken from this person blog, so thanks to him:
+// http://www.codesenior.com/en/tutorial/Spring-Generic-DAO-and-Generic-Service-Implementation
+// It is changed a bit: namely I haven't used Serializable id, but this may be
+// done later when I make this app testable, so that I'm not afraid to make
+// changes and check manually whether this page or this works
+public class GenericDaoImpl<T> implements GenericDao<T>{
+    // session factory: will be used in all concrete Dao implementations
+    @Autowired
+    protected SessionFactory sessionFactory;
+
+    // This member is needed to determine class type, because in `findAll`
+    // method and `findById` we need to get class instance. Using generic T
+    // we can know type of object, and in order to get the class instance we
+    // we create this member, that is created in constructor. Now I don't know
+    // how Spring knows about this constructor, but it is working. For now
+    // it is sufficient for me
+    protected Class<? extends T> daoType;
+
+    // unchecked warning added because of casting at the last line
+    // Main point of this constructor is to get instance of the class, ses
+    // comments to member `daoType` and this discussion:
+    // http://stackoverflow.com/questions/3437897/how-to-get-a-class-instance-of-generics-type-t
+    @SuppressWarnings("unchecked")
+    public GenericDaoImpl() {
+        Type type = getClass().getGenericSuperclass();
+        ParameterizedType parameterizedType = (ParameterizedType) type;
+        daoType = (Class) parameterizedType.getActualTypeArguments()[0];
+    }
+
+    // next methods are default CRUDs that will be re-usable for all our
+    // Dao implementations: Most of them are pretty straightforward:
+    // - open session
+    // - do something
+    // - close session
+    // in case of save/update and delete, theses methods include
+    // protocol:
+    // - begin transaction
+    // - do something
+    // - commit transaction
+
+    // warning is suppressed because of `.list()` part
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<T> findAll() {
+        Session session = sessionFactory.openSession();
+        List<T> objects = session.createCriteria(daoType).list();
+        session.close();
+        return objects;
+    }
+
+    // this method works double way: when new object is added, it is "saved"
+    // in database, when object exists, it is updated
+    @Override
+    public void save(T object) {
+        Session session = sessionFactory.openSession();
+        session.beginTransaction();
+        session.saveOrUpdate(object);
+        session.getTransaction().commit();
+        session.close();
+    }
+
+    @Override
+    public T findById(int objectId) {
+        Session session = sessionFactory.openSession();
+        T object = session.get(daoType, objectId);
+        session.close();
+        return object;
+    }
+
+    @Override
+    public void delete(T object) {
+        Session session = sessionFactory.openSession();
+        session.beginTransaction();
+        session.delete(object);
+        session.getTransaction().commit();
+        session.close();
+    }
+}

--- a/src/main/java/com/techdegree/instateam/dao/ProjectDao.java
+++ b/src/main/java/com/techdegree/instateam/dao/ProjectDao.java
@@ -8,5 +8,5 @@ public interface ProjectDao {
     List<Project> findAll();
     void save(Project project);
     Project findById(int projectId);
-    void remove(Project project);
+    void delete(Project project);
 }

--- a/src/main/java/com/techdegree/instateam/dao/ProjectDao.java
+++ b/src/main/java/com/techdegree/instateam/dao/ProjectDao.java
@@ -2,11 +2,5 @@ package com.techdegree.instateam.dao;
 
 import com.techdegree.instateam.model.Project;
 
-import java.util.List;
-
-public interface ProjectDao {
-    List<Project> findAll();
-    void save(Project project);
-    Project findById(int projectId);
-    void delete(Project project);
+public interface ProjectDao extends GenericDao<Project> {
 }

--- a/src/main/java/com/techdegree/instateam/dao/ProjectDaoImpl.java
+++ b/src/main/java/com/techdegree/instateam/dao/ProjectDaoImpl.java
@@ -13,9 +13,10 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public class ProjectDaoImpl implements ProjectDao {
-    @Autowired
-    private SessionFactory sessionFactory;
+public class ProjectDaoImpl
+        extends GenericDaoImpl<Project>
+        implements ProjectDao {
+    // "save", "findbyId" methods are implemented in GenericDaoImpl
 
     @Override
     @SuppressWarnings("unchecked")
@@ -32,23 +33,6 @@ public class ProjectDaoImpl implements ProjectDao {
         List<Project> projects = criteria.list();
         session.close();
         return projects;
-    }
-
-    @Override
-    public void save(Project project) {
-        Session session = sessionFactory.openSession();
-        session.beginTransaction();
-        session.saveOrUpdate(project);
-        session.getTransaction().commit();
-        session.close();
-    }
-
-    @Override
-    public Project findById(int projectId) {
-        Session session = sessionFactory.openSession();
-        Project project = session.get(Project.class, projectId);
-        session.close();
-        return project;
     }
 
     @Override

--- a/src/main/java/com/techdegree/instateam/dao/ProjectDaoImpl.java
+++ b/src/main/java/com/techdegree/instateam/dao/ProjectDaoImpl.java
@@ -52,7 +52,7 @@ public class ProjectDaoImpl implements ProjectDao {
     }
 
     @Override
-    public void remove(Project project) {
+    public void delete(Project project) {
         Session session = sessionFactory.openSession();
         // detach project from project_roles link table,
         session.createSQLQuery(

--- a/src/main/java/com/techdegree/instateam/dao/RoleDao.java
+++ b/src/main/java/com/techdegree/instateam/dao/RoleDao.java
@@ -2,11 +2,5 @@ package com.techdegree.instateam.dao;
 
 import com.techdegree.instateam.model.Role;
 
-import java.util.List;
-
-public interface RoleDao {
-    List<Role> findAll();
-    void save(Role role);
-    Role findById(int roleId);
-    void delete(Role role);
+public interface RoleDao extends GenericDao<Role> {
 }

--- a/src/main/java/com/techdegree/instateam/dao/RoleDaoImpl.java
+++ b/src/main/java/com/techdegree/instateam/dao/RoleDaoImpl.java
@@ -2,42 +2,14 @@ package com.techdegree.instateam.dao;
 
 import com.techdegree.instateam.model.Role;
 import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
-public class RoleDaoImpl implements RoleDao {
-    @Autowired
-    private SessionFactory sessionFactory;
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public List<Role> findAll() {
-        Session session = sessionFactory.openSession();
-        List<Role> roles = session.createCriteria(Role.class).list();
-        session.close();
-        return roles;
-    }
-
-    @Override
-    public void save(Role role) {
-        Session session = sessionFactory.openSession();
-        session.beginTransaction();
-        session.saveOrUpdate(role);
-        session.getTransaction().commit();
-        session.close();
-    }
-
-    @Override
-    public Role findById(int roleId) {
-        Session session = sessionFactory.openSession();
-        Role role = session.get(Role.class, roleId);
-        session.close();
-        return role;
-    }
+public class RoleDaoImpl
+        extends GenericDaoImpl<Role>
+        implements RoleDao {
+    // save, update and findAll() methods are implemented just like
+    // in GenericDaoImpl. Delete method however is different
 
     @Override
     public void delete(Role role) {

--- a/src/main/java/com/techdegree/instateam/dao/RoleDaoImpl.java
+++ b/src/main/java/com/techdegree/instateam/dao/RoleDaoImpl.java
@@ -42,6 +42,7 @@ public class RoleDaoImpl implements RoleDao {
     @Override
     public void delete(Role role) {
         Session session = sessionFactory.openSession();
+
         // update collaborators table by setting foreign key:
         // role_id in collaborators table to null
         session.createSQLQuery(
@@ -49,12 +50,22 @@ public class RoleDaoImpl implements RoleDao {
                         "SET ROLE_ID = NULL " +
                         "WHERE ROLE_ID = " + role.getId())
                 .executeUpdate();
+
         // update projects table by removing links to
         // deleted roles
         session.createSQLQuery(
                 "DELETE FROM PUBLIC.projects_roles " +
                         "WHERE ROLESNEEDED_ID = " + role.getId())
                 .executeUpdate();
+
+        // update projects collaborators table by removing collaborators
+        // that become inaccessible, because the role was deleted
+        // 1. find all collaborators with this roles
+        // SELECT FROM collaborators WHERE role_id = ?
+        // 2. from this collaborators find those who are in projects and delete
+        // DELETE FROM projects_collaborators WHERE collaborator_id = ?
+
+
         // delete role: begin transaction, delete, commit
         session.beginTransaction();
         session.delete(role);

--- a/src/main/java/com/techdegree/instateam/service/CollaboratorService.java
+++ b/src/main/java/com/techdegree/instateam/service/CollaboratorService.java
@@ -2,11 +2,5 @@ package com.techdegree.instateam.service;
 
 import com.techdegree.instateam.model.Collaborator;
 
-import java.util.List;
-
-public interface CollaboratorService {
-    List<Collaborator> findAll();
-    void save(Collaborator collaborator);
-    void delete(Collaborator collaborator);
-    Collaborator findById(int collaboratorId);
+public interface CollaboratorService extends GenericService<Collaborator> {
 }

--- a/src/main/java/com/techdegree/instateam/service/CollaboratorServiceImpl.java
+++ b/src/main/java/com/techdegree/instateam/service/CollaboratorServiceImpl.java
@@ -1,35 +1,29 @@
 package com.techdegree.instateam.service;
 
 import com.techdegree.instateam.dao.CollaboratorDao;
+import com.techdegree.instateam.dao.GenericDao;
 import com.techdegree.instateam.model.Collaborator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-public class CollaboratorServiceImpl implements CollaboratorService {
-    @Autowired
+public class CollaboratorServiceImpl
+        extends GenericServiceImpl<Collaborator>
+        implements CollaboratorService {
+
     private CollaboratorDao collaboratorDao;
 
-    @Override
-    public List<Collaborator> findAll() {
-       return collaboratorDao.findAll();
-    }
+    public CollaboratorServiceImpl() {
 
-    @Override
-    public void save(Collaborator collaborator) {
-        collaboratorDao.save(collaborator);
     }
-
-    @Override
-    public void delete(Collaborator collaborator) {
-        collaboratorDao.delete(collaborator);
+    @Autowired
+    public CollaboratorServiceImpl(
+            @Qualifier("collaboratorDaoImpl")
+                    GenericDao<Collaborator> genericDao) {
+        super(genericDao);
+        this.collaboratorDao = (CollaboratorDao) genericDao;
     }
-
-    @Override
-    public Collaborator findById(int collaboratorId) {
-        return collaboratorDao.findById(collaboratorId);
-    }
-
 }

--- a/src/main/java/com/techdegree/instateam/service/GenericService.java
+++ b/src/main/java/com/techdegree/instateam/service/GenericService.java
@@ -1,0 +1,10 @@
+package com.techdegree.instateam.service;
+
+import java.util.List;
+
+public interface GenericService<T> {
+    List<T> findAll();
+    void save(T object);
+    T findById(int objectId);
+    void delete(T object);
+}

--- a/src/main/java/com/techdegree/instateam/service/GenericServiceImpl.java
+++ b/src/main/java/com/techdegree/instateam/service/GenericServiceImpl.java
@@ -1,0 +1,59 @@
+package com.techdegree.instateam.service;
+
+import com.techdegree.instateam.dao.GenericDao;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+// Comments from codesenior.com
+// Every method is annotated as @Transactional. Thus, we guarantee that every
+// database operation will be wrapped with transaction. Also note that
+// genericDao field initiailization has to be made in the sub-classes of
+// GenericDaoImpl by using parameterized constructor. The reason behind is
+// that when multiple entity service classes which extends base
+// GenericServiceImpl is used, Spring has to decide which injection is made.
+// Therefore, we allow sub entity service classes to decide which generic
+// dao object will be injected by using @Qualifier annotation.
+public abstract class GenericServiceImpl<T>
+        implements GenericService<T> {
+    private GenericDao<T> genericDao;
+
+    public GenericServiceImpl() {
+
+    }
+
+    public GenericServiceImpl(GenericDao<T> genericDao) {
+        this.genericDao = genericDao;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    @Transactional(
+        propagation = Propagation.REQUIRED,
+        readOnly = true)
+    public List<T> findAll() {
+       return genericDao.findAll();
+    }
+
+    @Override
+    @Transactional(
+            propagation = Propagation.REQUIRED,
+            readOnly = true)
+    public T findById(int objectId) {
+        return genericDao.findById(objectId);
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void save(T object) {
+        genericDao.save(object);
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void delete(T object) {
+        genericDao.delete(object);
+    }
+
+}

--- a/src/main/java/com/techdegree/instateam/service/ProjectService.java
+++ b/src/main/java/com/techdegree/instateam/service/ProjectService.java
@@ -2,11 +2,5 @@ package com.techdegree.instateam.service;
 
 import com.techdegree.instateam.model.Project;
 
-import java.util.List;
-
-public interface ProjectService {
-    List<Project> findAll();
-    void save(Project project);
-    Project findById(int projectId);
-    void delete(Project project);
+public interface ProjectService extends GenericService<Project> {
 }

--- a/src/main/java/com/techdegree/instateam/service/ProjectServiceImpl.java
+++ b/src/main/java/com/techdegree/instateam/service/ProjectServiceImpl.java
@@ -29,6 +29,6 @@ public class ProjectServiceImpl implements ProjectService {
 
     @Override
     public void delete(Project project) {
-        projectDao.remove(project);
+        projectDao.delete(project);
     }
 }

--- a/src/main/java/com/techdegree/instateam/service/ProjectServiceImpl.java
+++ b/src/main/java/com/techdegree/instateam/service/ProjectServiceImpl.java
@@ -1,34 +1,26 @@
 package com.techdegree.instateam.service;
 
+import com.techdegree.instateam.dao.GenericDao;
 import com.techdegree.instateam.dao.ProjectDao;
 import com.techdegree.instateam.model.Project;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Service
-public class ProjectServiceImpl implements ProjectService {
-    @Autowired
+public class ProjectServiceImpl
+        extends GenericServiceImpl<Project>
+        implements ProjectService {
     private ProjectDao projectDao;
 
-    @Override
-    public List<Project> findAll() {
-       return projectDao.findAll();
-    }
+    public ProjectServiceImpl() {
 
-    @Override
-    public void save(Project project) {
-        projectDao.save(project);
     }
-
-    @Override
-    public Project findById(int projectId) {
-        return projectDao.findById(projectId);
-    }
-
-    @Override
-    public void delete(Project project) {
-        projectDao.delete(project);
+    @Autowired
+    public ProjectServiceImpl(
+            @Qualifier("projectDaoImpl")
+                    GenericDao<Project> genericDao) {
+        super(genericDao);
+        this.projectDao = (ProjectDao) genericDao;
     }
 }

--- a/src/main/java/com/techdegree/instateam/service/RoleService.java
+++ b/src/main/java/com/techdegree/instateam/service/RoleService.java
@@ -2,11 +2,5 @@ package com.techdegree.instateam.service;
 
 import com.techdegree.instateam.model.Role;
 
-import java.util.List;
-
-public interface RoleService {
-    List<Role> findAll();
-    void save(Role role);
-    Role findById(int roleId);
-    void delete(Role role);
+public interface RoleService extends GenericService<Role> {
 }

--- a/src/main/java/com/techdegree/instateam/service/RoleServiceImpl.java
+++ b/src/main/java/com/techdegree/instateam/service/RoleServiceImpl.java
@@ -1,34 +1,27 @@
 package com.techdegree.instateam.service;
 
+import com.techdegree.instateam.dao.GenericDao;
 import com.techdegree.instateam.dao.RoleDao;
 import com.techdegree.instateam.model.Role;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Service
-public class RoleServiceImpl implements RoleService {
-    @Autowired
+public class RoleServiceImpl
+        extends GenericServiceImpl<Role>
+        implements RoleService {
+
     private RoleDao roleDao;
 
-    @Override
-    public List<Role> findAll() {
-       return roleDao.findAll();
-    }
+    public RoleServiceImpl() {
 
-    @Override
-    public void save(Role role) {
-        roleDao.save(role);
     }
-
-    @Override
-    public Role findById(int roleId) {
-        return roleDao.findById(roleId);
-    }
-
-    @Override
-    public void delete(Role role) {
-        roleDao.delete(role);
+    @Autowired
+    public RoleServiceImpl(
+            @Qualifier("roleDaoImpl")
+                    GenericDao<Role> genericDao) {
+        super(genericDao);
+        this.roleDao = (RoleDao) genericDao;
     }
 }

--- a/src/main/java/com/techdegree/instateam/web/controller/ProjectController.java
+++ b/src/main/java/com/techdegree/instateam/web/controller/ProjectController.java
@@ -276,6 +276,12 @@ public class ProjectController {
             // cycle through projectCollaborators
             for (Collaborator projectCollaborator : project.getCollaborators()) {
 
+                // if role was removed from database, but collaborator left
+                // attached to project, we add null
+//                if (projectCollaborator.getRole() == null) {
+//                    projectCollaboratorsWithNullsForUnAssigned.add(null);
+//                    break;
+//                }
                 // if collaborator is assigned to this role: we check by
                 // unique ids
                 if (projectCollaborator.getRole().getId() ==


### PR DESCRIPTION
I was able to DRY code, by implementing generic interfaces at both Service and DAO layers: `GenericService` and `GenericDao`. Now all Role, Project and Collaborator DAO and Service interfaces implements these two generic interfaces. This was done by myself. The part with generalization of implementations was trickier. Although I understand almost everything in `GenericDaoImpl`, the service part is a bit trickier. But nevertheless thanks to "codesenior.com":
http://www.codesenior.com/en/tutorial/Spring-Generic-DAO-and-Generic-Service-Implementation
Absolutely wonderful description of how it is to be done. And using abstract class : which is the requirement for this project :)
