### PR TITLE
Try to make lazy instantitaion for all data retrieve

### DIFF
--- a/src/main/java/com/techdegree/instateam/dao/ProjectDao.java
+++ b/src/main/java/com/techdegree/instateam/dao/ProjectDao.java
@@ -3,4 +3,5 @@ package com.techdegree.instateam.dao;
 import com.techdegree.instateam.model.Project;
 
 public interface ProjectDao extends GenericDao<Project> {
+    Project findByIdWithRoleCollaboratorsInitialization(int projectId);
 }

--- a/src/main/java/com/techdegree/instateam/dao/ProjectDaoImpl.java
+++ b/src/main/java/com/techdegree/instateam/dao/ProjectDaoImpl.java
@@ -1,13 +1,10 @@
 package com.techdegree.instateam.dao;
 
 import com.techdegree.instateam.model.Project;
+import com.techdegree.instateam.model.Role;
 import org.hibernate.Criteria;
+import org.hibernate.Hibernate;
 import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.hibernate.criterion.DetachedCriteria;
-import org.hibernate.criterion.Projections;
-import org.hibernate.criterion.Subqueries;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,7 +13,26 @@ import java.util.List;
 public class ProjectDaoImpl
         extends GenericDaoImpl<Project>
         implements ProjectDao {
-    // "save", "findbyId" methods are implemented in GenericDaoImpl
+    // "save", method are implemented in GenericDaoImpl
+
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Project findByIdWithRoleCollaboratorsInitialization(int projectId) {
+        Session session = sessionFactory.openSession();
+        Project project = session.get(Project.class, projectId);
+        // lazy instantiate role.collaborators onlly for roles that are needed
+        // for project, because it is needed to
+        // assign rollaborators. When we use eager, we initialize and fetch
+        // all roles.collaborators from database. Now I do not know how to
+        // test this, and whether this approach is better, but that's the best
+        // I can to do here
+        for (Role role : project.getRolesNeeded()) {
+            Hibernate.initialize(role.getCollaborators());
+        }
+        session.close();
+        return project;
+    }
 
     @Override
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/techdegree/instateam/dao/ProjectDaoImpl.java
+++ b/src/main/java/com/techdegree/instateam/dao/ProjectDaoImpl.java
@@ -15,12 +15,27 @@ public class ProjectDaoImpl
         implements ProjectDao {
     // "save", method are implemented in GenericDaoImpl
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public Project findById(int projectId) {
+        System.out.println("HERE");
+        Session session = sessionFactory.openSession();
+        Project project = session.get(Project.class, projectId);
+        // initialize projects' roles needed
+        Hibernate.initialize(project.getRolesNeeded());
+        // initialize projects' collaborators
+        Hibernate.initialize(project.getCollaborators());
+        session.close();
+        return project;
+    }
 
     @SuppressWarnings("unchecked")
     @Override
     public Project findByIdWithRoleCollaboratorsInitialization(int projectId) {
         Session session = sessionFactory.openSession();
         Project project = session.get(Project.class, projectId);
+        // initialize projects' collaborators
+        Hibernate.initialize(project.getCollaborators());
         // lazy instantiate role.collaborators onlly for roles that are needed
         // for project, because it is needed to
         // assign rollaborators. When we use eager, we initialize and fetch

--- a/src/main/java/com/techdegree/instateam/model/Collaborator.java
+++ b/src/main/java/com/techdegree/instateam/model/Collaborator.java
@@ -1,10 +1,5 @@
 package com.techdegree.instateam.model;
 
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
-
 import javax.persistence.*;
 import javax.validation.constraints.Pattern;
 
@@ -26,7 +21,8 @@ public class Collaborator {
     private String name;
 
     // relation to role class, Many Collaborators can have one Role
-    // role removal deletes collaborators. Later is subject to change
+    // role removal detaches collaborators. Collaborators will get NULL
+    // in their role_id primary key, see `RoleDaoImpl.delete` method for more
     @ManyToOne(cascade = CascadeType.DETACH)
     private Role role;
 

--- a/src/main/java/com/techdegree/instateam/model/Project.java
+++ b/src/main/java/com/techdegree/instateam/model/Project.java
@@ -11,10 +11,43 @@ import java.util.List;
 @Entity
 @Table(name = "projects")
 public class Project {
+    // primary key - ID, should be changed to Long to implement Serializable
+    // but that's when I get testing for this done
     @Id
     @Column(name = "ID")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
+
+    // project name: alphanumeric VARCHAR
+    @Column(name = "NAME", columnDefinition = "VARCHAR")
+    @NotNull
+    @Pattern(regexp = "\\s*[a-zA-Z0-9]+(\\s+[a-zA-Z0-9]+)*\\s*",
+        message = "Name must consist of alphanumeric characters: a-Z, 0-9")
+    private String name;
+
+    // project description: for now it simply cannot be empty or null
+    // can be changed later
+    @Column(name = "DESCRIPTION", columnDefinition = "VARCHAR")
+    @NotNull(message = "Description cannot be empty")
+    private String description;
+
+    // project roles
+    @ManyToMany(fetch = FetchType.LAZY)
+    private List<Role> rolesNeeded;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    private List<Collaborator> collaborators;
+
+    // Project status is enum class, see definition, can be ACTIVE,
+    // NOT_STARTED, or ARCHIVED. In table it comes as INTEGER, has
+    // also style attributes, that makes project look different depending on
+    // status
+    @Enumerated
+    private ProjectStatus status;
+
+    //
+    // Getters and setters
+    //
     public int getId() {
         return id;
     }
@@ -22,11 +55,6 @@ public class Project {
         this.id = id;
     }
 
-    @Column(name = "NAME", columnDefinition = "VARCHAR")
-    @NotNull
-    @Pattern(regexp = "\\s*[a-zA-Z0-9]+(\\s+[a-zA-Z0-9]+)*\\s*",
-        message = "Name must consist of alphanumeric characters: a-Z, 0-9")
-    private String name;
     public String getName() {
         return name;
     }
@@ -34,9 +62,6 @@ public class Project {
         this.name = name;
     }
 
-    @Column(name = "DESCRIPTION", columnDefinition = "VARCHAR")
-    @NotNull(message = "Description cannot be empty")
-    private String description;
     public String getDescription() {
         return description;
     }
@@ -44,9 +69,6 @@ public class Project {
         this.description = description;
     }
 
-    @ManyToMany(fetch = FetchType.EAGER)
-    @Fetch(value = FetchMode.SUBSELECT)
-    private List<Role> rolesNeeded;
     public void setRolesNeeded(List<Role> rolesNeeded) {
         this.rolesNeeded = rolesNeeded;
     }
@@ -54,9 +76,6 @@ public class Project {
         return rolesNeeded;
     }
 
-    @ManyToMany(fetch = FetchType.EAGER)
-    @Fetch(value = FetchMode.SUBSELECT)
-    private List<Collaborator> collaborators;
     public List<Collaborator> getCollaborators() {
         return collaborators;
     }
@@ -64,9 +83,6 @@ public class Project {
         this.collaborators = collaborators;
     }
 
-
-    @Enumerated
-    private ProjectStatus status;
     public ProjectStatus getStatus() {
         return status;
     }

--- a/src/main/java/com/techdegree/instateam/model/Project.java
+++ b/src/main/java/com/techdegree/instateam/model/Project.java
@@ -1,8 +1,5 @@
 package com.techdegree.instateam.model;
 
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -31,10 +28,13 @@ public class Project {
     @NotNull(message = "Description cannot be empty")
     private String description;
 
-    // project roles
+    // project roles, are fetched lazily when `findById` method is called
+    // and `findByIdWithRoleCollaboratorsInitialization`
     @ManyToMany(fetch = FetchType.LAZY)
     private List<Role> rolesNeeded;
 
+    // project collaborators, are fetched lazily when both `findById` methods
+    // are called, see ProjectDaoImpl.
     @ManyToMany(fetch = FetchType.LAZY)
     private List<Collaborator> collaborators;
 
@@ -90,4 +90,8 @@ public class Project {
         this.status = status;
     }
 
+    // Default constructor for JPA
+    public Project() {
+
+    }
 }

--- a/src/main/java/com/techdegree/instateam/model/Role.java
+++ b/src/main/java/com/techdegree/instateam/model/Role.java
@@ -1,12 +1,8 @@
 package com.techdegree.instateam.model;
 
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -38,14 +34,14 @@ public class Role {
             message = "Name must consist of alphanumeric characters: a-Z, 0-9")
     private String name;
 
-    // collaborators column, mapped by role, many collaborators has one role
-    // on removal of role, right now collaborators are removed. Later will be
-    // changed.
-    // This list of collaborators is fetched eagerly, not lazily, I will
-    // investigate in this later.
+    // This column is mapped by role: which means, we have join column in
+    // "collaborators" table with foreign key "role_id". Fetch type is lazy:
+    // right now this is only used on "project collaborators" page, where
+    // only collaborators for needed for project roles are initialized and
+    // not all the roles
     @OneToMany(
             mappedBy = "role",
-            fetch = FetchType.EAGER
+            fetch = FetchType.LAZY
     )
     private List<Collaborator> collaborators;
 

--- a/src/main/java/com/techdegree/instateam/service/ProjectService.java
+++ b/src/main/java/com/techdegree/instateam/service/ProjectService.java
@@ -3,4 +3,5 @@ package com.techdegree.instateam.service;
 import com.techdegree.instateam.model.Project;
 
 public interface ProjectService extends GenericService<Project> {
+    Project findByIdWithRoleCollaboratorsInitialization(int projectId);
 }

--- a/src/main/java/com/techdegree/instateam/service/ProjectServiceImpl.java
+++ b/src/main/java/com/techdegree/instateam/service/ProjectServiceImpl.java
@@ -23,4 +23,10 @@ public class ProjectServiceImpl
         super(genericDao);
         this.projectDao = (ProjectDao) genericDao;
     }
+
+    @Override
+    public Project findByIdWithRoleCollaboratorsInitialization(int projectId) {
+        return projectDao
+                .findByIdWithRoleCollaboratorsInitialization(projectId);
+    }
 }

--- a/src/main/java/com/techdegree/instateam/web/controller/ProjectController.java
+++ b/src/main/java/com/techdegree/instateam/web/controller/ProjectController.java
@@ -9,6 +9,7 @@ import com.techdegree.instateam.service.CollaboratorService;
 import com.techdegree.instateam.service.ProjectService;
 import com.techdegree.instateam.service.RoleService;
 import com.techdegree.instateam.web.FlashMessage;
+import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -467,8 +468,17 @@ public class ProjectController {
             @PathVariable int projectId,
             Model model,
             RedirectAttributes redirectAttributes) {
-        // find project by id
-        Project project = projectService.findById(projectId);
+        // find project by id with role collaborators initialization
+        // now I'm not sure, whether this is important. But I trieed my best
+        // here we initialize collaborators for only project roles, so that
+        // when we use in template role.collaborators, we don't initialize
+        // whole database of roles. Now I don't know how to check how better
+        // this approach is: it seems logic, But i don't know how to test
+        // this
+        Project project =
+                projectService.findByIdWithRoleCollaboratorsInitialization(
+                        projectId
+                );
         // if not found throw error
         if (project == null) {
             throw new NotFoundException("Project not found");


### PR DESCRIPTION
Now all `collaborators` for Project and Role classes, as well as `rolesNeeded` for Project class are fetched lazily. Logic is introduced to fetch as less data as possible. Looks good. No testing yet. May be later. Also fixed Role deletion problem: by changing the order of queries. 
